### PR TITLE
Added warning about the lifecycle of an EFS file system created thru efs-create.config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ If you don't have pip, follow the instructions [here](http://docs.aws.amazon.com
 Modify the configuration files in the .ebextensions folder with the IDs of your [default VPC and subnets](https://console.aws.amazon.com/vpc/home#subnets:filter=default), and [your public IP address](https://www.google.com/search?q=what+is+my+ip). 
 
  - `.ebextensions/efs-create.config` creates an EFS file system and mount points in each Availability Zone / subnet in your VPC. Identify your default VPC and subnet IDs in the [VPC console](https://console.aws.amazon.com/vpc/home#subnets:filter=default). If you have not used the console before, use the region selector to select the same region that you chose for your environment.
+
+  ### WARNING: EFS lifecycle
+  Any resources that you create with configuration files are tied to the lifecycle of your environment. They are lost if you terminate your environment or remove the configuration file.
+  Use this configuration file to create an Amazon EFS file system in a development environment. When you no longer need the environment and terminate it, the file system is cleaned up for you.
+  For production environments, consider creating the file system using Amazon EFS directly.
+  For details, see [Creating an Amazon Elastic File System](http://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html).
  - `.ebextensions/ssh.config` restricts access to your environment to your IP address to protect it during the Drupal installation process. Replace the placeholder IP address near the top of the file with your public IP address.
 
 ## Deploy Drupal to your environment


### PR DESCRIPTION
The ebextension efs-create.config is ideal for a development environment - the EFS is deleted when you terminate your environment. In production, this is probably not the desired behavior. I added a warning that explains this distinction.