### PR TITLE
Drush command shortcut

### DIFF
--- a/.ebextensions/drush-cmd.config
+++ b/.ebextensions/drush-cmd.config
@@ -1,0 +1,16 @@
+files:
+    "/usr/bin/drush":
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+          cd /var/www/html || exit 1
+          DRUSH="./vendor/bin/drush"
+          if [ "$(whoami)" != "webapp" ]; then
+            SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+            sudo -uwebapp "$SCRIPTPATH/drush" $@
+            exit 0
+          fi
+          export $(cat /opt/elasticbeanstalk/deployment/env | xargs)
+          $DRUSH $@
+


### PR DESCRIPTION
*Description of changes:*

Using `eb ssh` is a comfortable way to debug things, but using `drush` is a must for Drupal sites. We need to use `webapp˙ user  to keep things tidy, also we should be able to directly access Drush like any other command, as it's critical for Drupal developers to perform various operations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
